### PR TITLE
Add timeout to minin-statsd.pl and redirect stdout/stderr to /dev/null.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -50,7 +50,7 @@ template "munin-statsd.pl" do
 end
 
 cron 'munin-statsd' do
-  command '/usr/local/bin/munin-statsd.pl'
+  command '/usr/bin/timeout --kill-after 10s 30s /usr/local/bin/munin-statsd.pl 2>&1 > /dev/null'
   only_if { File.exist?("/usr/local/bin/munin-statsd.pl") }
 end
 


### PR DESCRIPTION
This is a work-around for:
* https://rt.cpan.org/Public/Bug/Display.html?id=99750

This bug was fixed in:
* https://github.com/operasoftware/Munin-Node-Client/commit/0cd6a955ea3a4f8b83c4553f7009e86e59a82f3e

However, this is no deployment in CPAN with this fix.

Summary:
There is a bug in the munin node client code that causes an infinite
loop if a specific socket read call fails. What we were seeing is our
cron script running away, logging constantly to stderr (filling up
the mqueue) and eventually OOS the disk.

This workaround will run this command with a reasonable timeout
(half the interval of crontab) and redirect stdout/stderr to
/dev/null. In cases where this script has an issue, it should only
block for ~30s before it is killed and should not fill up the client
mail queue in the process.

Future:

Notes:
I am not sure if subsequent runs of this script will always fail
(socket error continues) or if terminating and re-starting the
process will be successful.

Solution:
This is just a work-around for the problem. The solution is to
get v0.02 of the Munin-Node-Client package into CPAN. This is being
tracked in:
https://github.com/operasoftware/Munin-Node-Client/issues/1